### PR TITLE
Delay restoration of current blog state until after the Loop ends

### DIFF
--- a/index.php
+++ b/index.php
@@ -38,6 +38,7 @@ class WP_Query_Multisite extends WP_Query{
             add_filter('posts_request', array(&$this, 'create_and_unionize_select_statements') );
             add_filter('posts_fields', array(&$this, 'add_site_ID_to_posts_fields') );
             add_action('the_post', array(&$this, 'switch_to_blog_while_in_loop'));
+            add_action('loop_end', array(&$this, 'restore_current_blog_after_loop'));
             
     }
     function remove_filters() {
@@ -87,8 +88,10 @@ class WP_Query_Multisite extends WP_Query{
         global $blog_id;
         if($post->site_ID && $blog_id != $post->site_ID )
            switch_to_blog($post->site_ID);
-        else
-           restore_current_blog();
+    }
+
+    function restore_current_blog_after_loop() {
+        restore_current_blog();
     }
 }
 


### PR DESCRIPTION
Prior to this change, the last post in the loop would have the wrong blog context when the WP_Query_Multisite loop was executed on a blog other than the one that post belonged to. (In my case, the root "network site", which has no posts of its own.)